### PR TITLE
stdin support

### DIFF
--- a/src/whisper_ctranslate2/whisper_ctranslate2.py
+++ b/src/whisper_ctranslate2/whisper_ctranslate2.py
@@ -478,9 +478,6 @@ def main():
             with tempfile.NamedTemporaryFile(mode='wb', delete=False) as temp_file:
                 temp_file.write(pipe_data)
                 audio = [temp_file.name]
-                print(audio)
-
-    print(audio)
 
 
     word_options = ["highlight_words", "max_line_count", "max_line_width"]
@@ -568,7 +565,7 @@ def main():
     for audio_path in audio:
         if verbose and len(audio) > 1:
             print(f"\nFile: '{audio_path}'")
-        print(f"\nFile: '{audio_path}'")
+            
         result = transcribe.inference(
             audio_path,
             task,

--- a/src/whisper_ctranslate2/whisper_ctranslate2.py
+++ b/src/whisper_ctranslate2/whisper_ctranslate2.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import tempfile
 from .transcribe import Transcribe, TranscriptionOptions
 from .languages import LANGUAGES, TO_LANGUAGE_CODE, from_language_to_iso_code
 import numpy as np
@@ -465,7 +466,6 @@ def main():
         vad_min_silence_duration_ms=args.pop("vad_min_silence_duration_ms"),
     )
 
-    pipe_data: BinaryIO = sys.stdin.buffer.read()
     if not live_transcribe and len(audio) == 0:
         pipe_data: BinaryIO = sys.stdin.buffer.read()
         if len(pipe_data) == 0:
@@ -474,6 +474,14 @@ def main():
                 "Use `whisper-ctranslate2 --help` to see the available options.\n"
             )
             return
+        else:
+            with tempfile.NamedTemporaryFile(mode='wb', delete=False) as temp_file:
+                temp_file.write(pipe_data)
+                audio = [temp_file.name]
+                print(audio)
+
+    print(audio)
+
 
     word_options = ["highlight_words", "max_line_count", "max_line_width"]
     if not options.word_timestamps:
@@ -556,23 +564,11 @@ def main():
         local_files_only,
     )
 
-    if len(pipe_data) > 0:
-        if verbose and len(audio) > 1:
-            print(f"\nPipe Data")
-
-        result = transcribe.inference(
-            pipe_data,
-            task,
-            language,
-            verbose,
-            False,
-            options,
-        )
 
     for audio_path in audio:
         if verbose and len(audio) > 1:
             print(f"\nFile: '{audio_path}'")
-
+        print(f"\nFile: '{audio_path}'")
         result = transcribe.inference(
             audio_path,
             task,


### PR DESCRIPTION
cat sound.wav | whisper-ctranslate2

Changed src/whisper-ctranslate2.py. Edits the check for no audio cli argument and no live transcribe.. If there is stdin data then a new temporary file is created and written to with the stdin data, then updates the audio ( cli argument ) to be the newly created temporary file.

The purpose of this is to allow foreign programs written in other languages to pipe in data to whisper-ctranslate2.