### PR TITLE
More natural line-wrapping when using --max_line_width

### DIFF
--- a/src/whisper_ctranslate2/writers.py
+++ b/src/whisper_ctranslate2/writers.py
@@ -5,6 +5,7 @@
 import os
 import json
 import re
+import copy
 from typing import Callable, TextIO, Optional
 
 
@@ -60,47 +61,82 @@ class SubtitlesWriter(ResultWriter):
         max_line_width = 1000 if raw_max_line_width is None else raw_max_line_width
         preserve_segments = max_line_count is None or raw_max_line_width is None
 
+        # Splits a line based on commas or word gaps
+        def split_lineIfNeeded(words, max_splits=12):
+            # If there are no words or we have no more splits left, return an empty list
+            if not words or max_splits <= 0:
+                return [{'words': words}]
+            
+            # If the length of the words is less or equal to n, return the words as they are.
+            if len("".join([word['word'] for word in words])) <= max_line_width:
+                return [{'words': words}]
+
+            # Find the index of the comma closest to the middle of the line
+            middle = len(words) // 2
+            comma_indices = [i for i, word in enumerate(words[:-1]) if ',' in word['word']]
+            closest_comma_index = min(comma_indices, key=lambda idx: abs(middle - idx), default=None)
+
+            #discard comma index if it's too close to the beginning or end of the line
+            if closest_comma_index is not None and closest_comma_index < len(words) // 5:
+                closest_comma_index = None
+
+            # If there's no comma, find the largest gap among approximately 20% of words (/5) around the center
+            if closest_comma_index is None:
+                window_start = max(0, middle - len(words) // 5)
+                window_end = min(len(words), middle + len(words) // 5)
+                max_gap_size = 0
+                for i in range(window_start, window_end - 1):
+                    gap_size = words[i + 1]['start'] - words[i]['end']
+                    if gap_size > max_gap_size:
+                        max_gap_size = gap_size
+                        closest_comma_index = i
+
+            # If there's still no suitable split point (no comma and no gap found), split at the middle
+            if closest_comma_index is None:
+                closest_comma_index = middle
+
+            # Splitting the line at the closest comma or the largest gap
+            left_part = words[:closest_comma_index + 1]
+            right_part = words[closest_comma_index + 1:]
+
+            # Recursively check if the split parts need further splitting
+            split_left_part = split_lineIfNeeded(left_part, max_splits-1)
+            split_right_part = split_lineIfNeeded(right_part, max_splits-1)
+
+            return split_left_part + split_right_part
+        
+        #Yield successive chunks from lst of size chunk_size.
+        def chunks(lst, chunk_size):
+            for i in range(0, len(lst), chunk_size):
+                yield lst[i:i + chunk_size]
+
         def iterate_subtitles():
-            line_len = 0
-            line_count = 1
-            # the next subtitle to yield (a list of word timings with whitespace)
-            subtitle: list[dict] = []
-            last = result["segments"][0]["words"][0]["start"]
-            for segment in result["segments"]:
-                speaker = f"[{segment['speaker']}]: " if "speaker" in segment else ""
+            output_subtitles = [] # All of the output subtitles
+            result_copy = copy.deepcopy(result) # Copy of the result to be modified
+            for segment in result_copy["segments"]:
+                output_subtitles_buffer = [] # All the split subtitles resulting from the current segment
+                speaker = f"[{segment['speaker']}]: " if "speaker" in segment else "" # Speaker for the current segment
 
-                for i, original_timing in enumerate(segment["words"]):
-                    timing = original_timing.copy()
-                    long_pause = not preserve_segments and timing["start"] - last > 3.0
-                    has_room = line_len + len(timing["word"]) <= max_line_width
-                    seg_break = i == 0 and len(subtitle) > 0 and preserve_segments
-                    if line_len > 0 and has_room and not long_pause and not seg_break:
-                        # line continuation
-                        line_len += len(timing["word"])
-                    else:
-                        # new line
-                        timing["word"] = speaker + timing["word"].strip()
-                        speaker = ""
-                        if (
-                            len(subtitle) > 0
-                            and max_line_count is not None
-                            and (long_pause or line_count >= max_line_count)
-                            or seg_break
-                        ):
-                            # subtitle break
-                            yield subtitle
-                            subtitle = []
-                            line_count = 1
-                        elif line_len > 0:
-                            # line break
-                            line_count += 1
-                            timing["word"] = "\n" + timing["word"]
-                        line_len = len(timing["word"].strip())
-                    subtitle.append(timing)
-                    last = timing["start"]
-            if len(subtitle) > 0:
-                yield subtitle
+                for group_of_lines in chunks(split_lineIfNeeded(segment["words"]), max_line_count):
+                    output_line = [] # A single subtitle, composed of multiple raw_line in a group_of_lines, joined with a linebreak.
+                    for raw_line in group_of_lines: # A raw_line is a single line. Multiple raw_line make up a subtitle, concatenated with linebreaks inserted in words where needed.
+                        is_last_line = raw_line == group_of_lines[-1]
+                        if not is_last_line: # All but the last line should have a linebreak at the end
+                            raw_line["words"][0]["word"] = raw_line["words"][0]["word"].lstrip() # Remove leading space from first word.
+                            raw_line["words"][-1]["word"] = raw_line["words"][-1]["word"].rstrip() + "\n" # Replace trailing space in last word with linebreak
+                        else: #The last line should not have a linebreak at the end
+                            raw_line["words"][0]["word"] = raw_line["words"][0]["word"].lstrip() # Remove leading space from first word.
+                            raw_line["words"][-1]["word"] = raw_line["words"][-1]["word"].rstrip() # Remove trailing space from last word.
+                        output_line.extend(raw_line["words"])
 
+                    word_already_has_speaker = output_line[0]["word"].startswith(speaker) # Ensure the speaker is only added once
+                    if not word_already_has_speaker:
+                        output_line[0]["word"] = speaker + output_line[0]["word"].lstrip() # Add speaker to first word of subtitle
+
+                    output_subtitles_buffer.append(output_line)
+                output_subtitles.extend(output_subtitles_buffer)
+            return output_subtitles
+                                
         if (
             len(result["segments"]) > 0
             and "words" in result["segments"][0]
@@ -109,7 +145,7 @@ class SubtitlesWriter(ResultWriter):
             for subtitle in iterate_subtitles():
                 subtitle_start = self.format_timestamp(subtitle[0]["start"])
                 subtitle_end = self.format_timestamp(subtitle[-1]["end"])
-                subtitle_text = "".join([word["word"] for word in subtitle])
+                subtitle_text = "".join([word["word"] for word in subtitle]).strip()
                 if highlight_words:
                     last = subtitle_start
                     all_words = [timing["word"] for timing in subtitle]


### PR DESCRIPTION
By default, Whisper produces subtitles (SRT/VTT) with often quite long line-lengths. For some uses these can be too long for viewers to comfortably read. (a common recommendation is that subtitles should be ~50 characters maximum lenghth). For example, testing with "[The Expert](https://www.youtube.com/watch?v=BKorP55Aqvg")"
```

1
00:00:00,000 --> 00:00:04,440
Our company has a new strategic initiative to increase market penetration,

2
00:00:05,120 --> 00:00:07,720
maximise brand loyalty and enhance intangible assets.

3
00:00:08,080 --> 00:00:13,660
In pursuit of these objectives, we've started a new project for which we require seven red lines.

```
If I want them shorter, I can use something like `--max_line_count 2 --max_line_width 50` which does result in very consistent, short lines, but the current line-wrapping implementation results in subtitles which are quite unnatural to read, due to line- and subtitle- breaks not being on (sub)-sentences.
```

1
00:00:00,000 --> 00:00:05,800
Our company has a new strategic initiative to
increase market penetration, maximise brand

2
00:00:05,800 --> 00:00:11,700
loyalty and enhance intangible assets. In pursuit
of these objectives, we've started a new project

3
00:00:11,700 --> 00:00:16,480
for which we require seven red lines. I understand
your company can help us in this matter. Of
```

This PR changes this, by wrapping lines in a more natural way, splitting them on periods or commas if possible, and otherwise on the longest gap around the middle of the too-long line. It results in more natural to read text, while staying within the set `--max_line_width` constraint:

```
1
00:00:00,000 --> 00:00:04,440
Our company has a new strategic
initiative to increase market penetration,

2
00:00:05,120 --> 00:00:07,720
maximise brand loyalty and
enhance intangible assets.

3
00:00:08,080 --> 00:00:12,060
In pursuit of these objectives,
we've started a new project for which

4
00:00:12,060 --> 00:00:13,660
we require seven red lines.
```

I've tested that:

* Diarization output is the same
* Works regardless of language
* The JSON output is not changed

I'm not super familiar with Python, so this code is probably not the nicest. Any feedback is appreciated!