### PR TITLE
add arg for sampling rate

### DIFF
--- a/src/whisper_ctranslate2/commandline.py
+++ b/src/whisper_ctranslate2/commandline.py
@@ -439,4 +439,11 @@ class CommandLine:
             help="Set live stream input device ID (see python -m sounddevice for a list)",
         )
 
+        live_args.add_argument(
+            "--live_input_device_sample_rate",
+            type=int,
+            default=16000,
+            help="Set live sample rate of input device",
+        )
+
         return parser.parse_args().__dict__

--- a/src/whisper_ctranslate2/live.py
+++ b/src/whisper_ctranslate2/live.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from .transcribe import Transcribe, TranscriptionOptions
 
-SampleRate = 16000  # Stream device recording frequency per second
 BlockSize = 30  # Block size in milliseconds
 Vocals = [50, 1000]  # Frequency range to detect sounds that could be speech
 EndBlocks = 33 * 2  # Number of blocks to wait before sending (30 ms is block)
@@ -38,6 +37,7 @@ class Live:
         verbose: bool,
         threshold: float,
         input_device: int,
+        input_device_sample_rate: int,
         options: TranscriptionOptions,
     ):
         self.model_path = model_path
@@ -52,6 +52,7 @@ class Live:
         self.verbose = verbose
         self.threshold = threshold
         self.input_device = input_device
+        self.input_device_sample_rate = input_device_sample_rate
         self.options = options
 
         self.running = True
@@ -71,7 +72,11 @@ class Live:
         raise (sounddevice_exception)
 
     def _is_there_voice(self, indata, frames):
-        freq = np.argmax(np.abs(np.fft.rfft(indata[:, 0]))) * SampleRate / frames
+        freq = (
+            np.argmax(np.abs(np.fft.rfft(indata[:, 0])))
+            * self.input_device_sample_rate
+            / frames
+        )
         volume = np.sqrt(np.mean(indata**2))
 
         return volume > self.threshold and Vocals[0] <= freq <= Vocals[1]
@@ -158,8 +163,8 @@ class Live:
         with sd.InputStream(
             channels=1,
             callback=self.callback,
-            blocksize=int(SampleRate * BlockSize / 1000),
-            samplerate=SampleRate,
+            blocksize=int(self.input_device_sample_rate * BlockSize / 1000),
+            samplerate=self.input_device_sample_rate,
             device=self.input_device,
         ):
             while self.running:

--- a/src/whisper_ctranslate2/whisper_ctranslate2.py
+++ b/src/whisper_ctranslate2/whisper_ctranslate2.py
@@ -114,6 +114,7 @@ def main():
     local_files_only: bool = args.pop("local_files_only")
     live_volume_threshold: float = args.pop("live_volume_threshold")
     live_input_device: int = args.pop("live_input_device")
+    live_input_device_sample_rate: int = args.pop("live_input_device_sample_rate")
     hf_token = args.pop("hf_token")
     speaker_name = args.pop("speaker_name")
     batched = args.pop("batched")
@@ -202,6 +203,7 @@ def main():
             verbose,
             live_volume_threshold,
             live_input_device,
+            live_input_device_sample_rate,
             options,
         ).inference()
 


### PR DESCRIPTION
Some input devices give errors (e.g. scarlett ) if frequency is not set to device frequency. 

```bash
python -m sounddevice
#    0 HDA Intel PCH: ALC1220 Analog (hw:0,0), ALSA (2 in, 8 out)
#    1 HDA Intel PCH: ALC1220 Digital (hw:0,1), ALSA (0 in, 2 out)
#    2 HDA Intel PCH: ALC1220 Alt Analog (hw:0,2), ALSA (2 in, 0 out)
#    3 HDA NVidia: HDMI 0 (hw:1,3), ALSA (0 in, 8 out)
#    4 HDA NVidia: PHL 272P7VU (hw:1,7), ALSA (0 in, 2 out)
#    5 HDA NVidia: HDMI 2 (hw:1,8), ALSA (0 in, 8 out)
#    6 HDA NVidia: HDMI 3 (hw:1,9), ALSA (0 in, 8 out)
#    7 HDA NVidia: HDMI 4 (hw:1,10), ALSA (0 in, 8 out)
#    8 HDA NVidia: HDMI 5 (hw:1,11), ALSA (0 in, 8 out)
#    9 HDA NVidia: HDMI 6 (hw:1,12), ALSA (0 in, 8 out)
#   10 Scarlett 2i2 USB: Audio (hw:2,0), ALSA (2 in, 0 out)   <-- attempting to use this one
#   11 sysdefault, ALSA (128 in, 128 out)
#   12 front, ALSA (0 in, 8 out)
#   13 surround21, ALSA (0 in, 128 out)
#   14 surround40, ALSA (0 in, 8 out)
#   15 surround41, ALSA (0 in, 128 out)
#   16 surround50, ALSA (0 in, 128 out)
#   17 surround51, ALSA (0 in, 8 out)
#   18 surround71, ALSA (0 in, 8 out)
#   19 iec958, ALSA (0 in, 2 out)
#   20 spdif, ALSA (0 in, 2 out)
# * 21 default, ALSA (128 in, 128 out)
#   22 dmix, ALSA (0 in, 2 out)
```

```bash
whisper-ctranslate2 --live_transcribe True --live_input_device="10" --device=cuda --model medium
# Expression 'paInvalidSampleRate' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 2048
# Expression 'PaAlsaStreamComponent_InitialConfigure( &self->capture, inParams, self->primeBuffers, hwParamsCapture, &realSr )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 2718
# Expression 'PaAlsaStream_Configure( stream, inputParameters, outputParameters, sampleRate, framesPerBuffer, &inputLatency, &outputLatency, &hostBufferSizeMode )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 2842
# Consider specifying the language using `--language`. It improves significantly prediction in live transcription.
# [32mLive stream device: [37mScarlett 2i2 USB: Audio (hw:2,0)[0m
# [32mListening.. [37m(Ctrl+C to Quit)[0m
# 
# [93mQuitting..[0m
# Traceback (most recent call last):
#   File "/lsiopy/bin/whisper-ctranslate2", line 8, in <module>
#     sys.exit(main())
#              ^^^^^^
#   File "/lsiopy/lib/python3.12/site-packages/src/whisper_ctranslate2/whisper_ctranslate2.py", line 206, in main
#     ).inference()
#       ^^^^^^^^^^^
#   File "/lsiopy/lib/python3.12/site-packages/src/whisper_ctranslate2/live.py", line 170, in inference
#     self.listen()
#   File "/lsiopy/lib/python3.12/site-packages/src/whisper_ctranslate2/live.py", line 158, in listen
#     with sd.InputStream(
#          ^^^^^^^^^^^^^^^
#   File "/lsiopy/lib/python3.12/site-packages/sounddevice.py", line 1440, in __init__
#     _StreamBase.__init__(self, kind='input', wrap_callback='array',
#   File "/lsiopy/lib/python3.12/site-packages/sounddevice.py", line 909, in __init__
#     _check(_lib.Pa_OpenStream(self._ptr, iparameters, oparameters,
#   File "/lsiopy/lib/python3.12/site-packages/sounddevice.py", line 2796, in _check
#     raise PortAudioError(errormsg, err)
# sounddevice.PortAudioError: Error opening InputStream: Invalid sample rate [PaErrorCode -9997]
```

```bash
# to get the sample rate: 
arecord -D "hw:2,0" -f cd 
#Recording WAVE 'stdin' : Signed 16 bit Little Endian, Rate 44100 Hz, Stereo
#arecord: set_params:1352: Sample format non available
#Available formats:
#- S32_LE
```
```bash
# with this PR
python -m src.whisper_ctranslate2.whisper_ctranslate2 --live_transcribe True --live_input_device=10 --live_input_device_sample_rate=44100 --device=cuda --model medium
# Consider specifying the language using `--language`. It improves significantly prediction in live transcription.
# Live stream device: Scarlett 2i2 USB: Audio (hw:2,0)
# Listening.. (Ctrl+C to Quit)
# ....
#  Shhh, shhh, shhh, shhh, shhh.
# ...............
#  This is a test. This is a test.
# 
#
```
