### PR TITLE
Add support for faster-whisper multilingual option

### DIFF
--- a/src/whisper_ctranslate2/commandline.py
+++ b/src/whisper_ctranslate2/commandline.py
@@ -364,6 +364,13 @@ class CommandLine:
             help="When using Batched transcription the maximum number of parallel requests to model for decoding.",
         )
 
+        algorithm_args.add_argument(
+            "--multilingual",
+            type=CommandLine._str2bool,
+            default=False,
+            help="Perform language detection on every segment",
+        )
+
         vad_args = parser.add_argument_group("VAD filter arguments")
 
         vad_args.add_argument(

--- a/src/whisper_ctranslate2/transcribe.py
+++ b/src/whisper_ctranslate2/transcribe.py
@@ -52,6 +52,7 @@ class TranscriptionOptions(NamedTuple):
     vad_min_speech_duration_ms: Optional[int]
     vad_max_speech_duration_s: Optional[int]
     vad_min_silence_duration_ms: Optional[int]
+    multilingual: bool
 
 
 class Transcribe:
@@ -179,6 +180,7 @@ class Transcribe:
             vad_filter=vad,
             vad_parameters=vad_parameters,
             **batch_size,
+            multilingual=options.multilingual,
         )
 
         language_name = LANGUAGES[info.language].title()

--- a/src/whisper_ctranslate2/whisper_ctranslate2.py
+++ b/src/whisper_ctranslate2/whisper_ctranslate2.py
@@ -74,6 +74,7 @@ def get_transcription_options(args):
         vad_min_speech_duration_ms=args.pop("vad_min_speech_duration_ms"),
         vad_max_speech_duration_s=args.pop("vad_max_speech_duration_s"),
         vad_min_silence_duration_ms=args.pop("vad_min_silence_duration_ms"),
+        multilingual=args.pop("multilingual"),
     )
 
 


### PR DESCRIPTION
fixes https://github.com/Softcatala/whisper-ctranslate2/issues/119

The faster-whisper multilingual option allows language detection to be performed on each segment. With the multilingual option enabled, you can get better transcription results if the language was incorrectly detected in the first place, or if the spoken language is switched in the audio.