### PR TITLE
Allow setting output_dir to "" to disable writing files

### DIFF
--- a/src/whisper_ctranslate2/commandline.py
+++ b/src/whisper_ctranslate2/commandline.py
@@ -92,7 +92,7 @@ class CommandLine:
             "-o",
             type=str,
             default=".",
-            help="Directory to save the outputs",
+            help='Directory to save the outputs (set to "" to disable writing files)',
         )
         outputs_args.add_argument(
             "--output_format",

--- a/src/whisper_ctranslate2/whisper_ctranslate2.py
+++ b/src/whisper_ctranslate2/whisper_ctranslate2.py
@@ -100,7 +100,8 @@ def main():
     args = CommandLine().read_command_line()
     output_dir: str = args.pop("output_dir")
     output_format: str = args.pop("output_format")
-    os.makedirs(output_dir, exist_ok=True)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     model: str = args.pop("model")
     threads: int = args.pop("threads")
     language: str = args.pop("language")
@@ -189,7 +190,8 @@ def main():
             "Print colors requires word-level time stamps. Generated files in output directory will have word-level timestamps"
         )
 
-    output_dir = os.path.abspath(output_dir)
+    if output_dir:
+        output_dir = os.path.abspath(output_dir)
     if model_directory:
         model_filename = os.path.join(model_directory, "model.bin")
         if not os.path.exists(model_filename):
@@ -292,7 +294,10 @@ def main():
             continue
 
     if verbose:
-        print(f"Transcription results written to '{output_dir}' directory")
+        if output_dir:
+            print(f"Transcription results written to '{output_dir}' directory")
+        else:
+            print("No output directory specified; skipping writing output files")
 
 
 if __name__ == "__main__":

--- a/src/whisper_ctranslate2/writers.py
+++ b/src/whisper_ctranslate2/writers.py
@@ -37,6 +37,9 @@ class ResultWriter:
         self.output_dir = output_dir
 
     def __call__(self, result: dict, audio_path: str, options: dict):
+        if not self.output_dir:
+            return
+
         audio_basename = os.path.basename(audio_path)
         audio_basename = os.path.splitext(audio_basename)[0]
         output_path = os.path.join(


### PR DESCRIPTION
Useful for use cases where stdout is parsed as it is printed.

Addresses #89.